### PR TITLE
Updated pimple version to 3.x branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 
     "require" : {
         "php" : ">=5.4.0",
-        "pimple/pimple" : "2.1.x-dev",
+        "pimple/pimple" : "~3.0",
         "silex/api" : "2.0.x-dev"
     },
 


### PR DESCRIPTION
Silex 2.x branch uses pimple 3.x one so with the current constraints in composer.json it was not possible to install the flint/providers package, this PR updates the pimple version in order to be able to use the package with Silex 2.x branch.
